### PR TITLE
Fix build on docs.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,11 @@ use std::fs;
 use typify::{TypeSpace, TypeSpaceSettings};
 
 fn main() {
+    if std::env::var("DOCS_RS").is_ok() {
+        // if running on doc_rs the fs wis read only so we won't be able to updatte the schema
+        return;
+    }
+
     let content = std::fs::read_to_string("src/nats_jwt_schema.json").unwrap();
     let schema = serde_json::from_str::<schemars::schema::RootSchema>(&content).unwrap();
 


### PR DESCRIPTION
build.rs is failing on docs.rs because it looks
like it is trying to write to a read only FS.

It is unnecessary to regenerate the schema when building docs so simply put an ENV check in to skip this step on docs.rs